### PR TITLE
first getopt-win32 build

### DIFF
--- a/recipe/CMakeLists.txt
+++ b/recipe/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.0)
+
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+project(getopt LANGUAGES C)
+add_definitions(-DEXPORTS_GETOPT)
+add_library(getopt SHARED getopt.h getopt.c)
+ 
+install(TARGETS getopt
+    RUNTIME DESTINATION "bin"
+    ARCHIVE DESTINATION "lib"
+    LIBRARY DESTINATION "lib"
+    )
+install(FILES getopt.h DESTINATION include)

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,9 +1,37 @@
-set getopt_build_mode=Release
-set getopt_build_arch=x%ARCH%
+@echo ON
+setlocal enabledelayedexpansion
 
-msbuild /p:Configuration=%getopt_build_mode%
-if errorlevel 1 exit 1
+:: Custom cmake file
+copy %RECIPE_DIR%\CMakeLists.txt %SRC_DIR%\
 
-copy %getopt_build_arch%\%getopt_build_mode%\getopt.dll %LIBRARY_BIN%
-copy %getopt_build_arch%\%getopt_build_mode%\getopt.lib %LIBRARY_LIB%
-copy %SRC_DIR%\getopt.h                                 %LIBRARY_INC%
+:: cmd
+echo "Building %PKG_NAME%."
+
+:: Isolate the build.
+mkdir Build-%PKG_NAME%
+cd Build-%PKG_NAME%
+if errorlevel 1 exit /b 1
+
+:: Generate the build files.
+echo "Generating the build files..."
+cmake .. %CMAKE_ARGS% ^
+      -G"Ninja" ^
+      -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -DCMAKE_BUILD_TYPE=Release
+type ./CMakeFiles/CMakeOutput.log
+::if errorlevel 1 exit /b 1
+
+:: Build.
+echo "Building..."
+ninja
+if errorlevel 1 exit /b 1
+
+:: Install.
+echo "Installing..."
+ninja install
+if errorlevel 1 exit /b 1
+
+:: Error free exit.
+echo "Error free exit!"
+exit 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "getopt-win32" %}
 {% set version = "0.1" %}
-# Note: This recipe needs the v140 platform toolset installed for visual studio to build.
 package:
   name: {{ name }}
   version: {{ version }}
@@ -18,6 +17,8 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - cmake
+    - ninja-base
 
 test:
   commands:
@@ -32,6 +33,7 @@ about:
   license_file: LICENSE
   summary: 'A port of getopt for Visual C++'
   dev_url: https://github.com/libimobiledevice-win32/getopt
+  doc_url: https://github.com/libimobiledevice-win32/getopt/blob/master/article.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Required for graphviz win build.
dev:  https://github.com/libimobiledevice-win32/getopt
license: https://github.com/libimobiledevice-win32/getopt/blob/master/LICENSE
doc: https://github.com/libimobiledevice-win32/getopt/blob/master/article.md
jira: https://anaconda.atlassian.net/browse/DSNC-4958

Changes:
- Add cmake build instead of using vs project specific to vs2015.
- Add doc_url

https://concourse.build.corp.continuum.io/teams/main/pipelines/cbousseau_getopt-win32